### PR TITLE
Fix join/create form validation and color constant

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -35,7 +35,7 @@ export const PLAYER_COLORS: PlayerColor[] = [
     name: "Yellow",
     hex: "#ffcc00",
     hover: "#e6b800",
-    text: "#text-black",
+    text: "text-black",
     bg: "bg-yellow",
     hoverBg: "hover:bg-yellow-hover",
     border: "border-yellow",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -46,7 +46,7 @@ export default function Home() {
               <button
                 className="purple-button w-full"
                 onClick={initRoom}
-                disabled={!name && name.length <= 4}
+                disabled={!name || name.length <= 4}
               >
                 Create Room
               </button>
@@ -67,7 +67,7 @@ export default function Home() {
               />
               <button
                 className="purple-button w-full"
-                disabled={!roomCode && roomCode.length !== 5}
+                disabled={!roomCode || roomCode.length !== 5}
                 onClick={() => navigate("/" + roomCode)}
               >
                 Join Room


### PR DESCRIPTION
## Summary
- enforce length check in room creation/join buttons
- fix yellow color configuration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f6602aa34832b894afdf56b4ea0f2