### PR TITLE
Add Jest tests for utilities

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@assets/(.*)$': '<rootDir>/src/assets/$1',
+    '^@components/(.*)$': '<rootDir>/src/components/$1',
+    '^@data/(.*)$': '<rootDir>/src/data/$1',
+    '^@lib/(.*)$': '<rootDir>/src/lib/$1',
+    '^@pages/(.*)$': '<rootDir>/src/pages/$1',
+    '^@stores/(.*)$': '<rootDir>/src/stores/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",
@@ -30,6 +31,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "@types/jest": "^29.5.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"

--- a/src/data/__tests__/constants.test.ts
+++ b/src/data/__tests__/constants.test.ts
@@ -1,0 +1,13 @@
+import { getColor, PLAYER_COLORS } from '../constants';
+
+describe('getColor', () => {
+  it('returns a color by name', () => {
+    const red = getColor('Red');
+    expect(red).toBeDefined();
+    expect(red.hex).toBe('#ff0000');
+  });
+
+  it('returns undefined for unknown colors', () => {
+    expect(getColor('Unknown')).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/math.test.ts
+++ b/src/lib/__tests__/math.test.ts
@@ -1,0 +1,21 @@
+import { pointLerp } from '../math';
+
+describe('pointLerp', () => {
+  it('returns the start point when t=0', () => {
+    const a = { x: 0, y: 0 };
+    const b = { x: 10, y: 10 };
+    expect(pointLerp(a, b, 0)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('returns the end point when t=1', () => {
+    const a = { x: 0, y: 0 };
+    const b = { x: 10, y: 10 };
+    expect(pointLerp(a, b, 1)).toEqual({ x: 10, y: 10 });
+  });
+
+  it('interpolates halfway when t=0.5', () => {
+    const a = { x: 0, y: 0 };
+    const b = { x: 10, y: 10 };
+    expect(pointLerp(a, b, 0.5)).toEqual({ x: 5, y: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest
- add tests for `pointLerp`
- add tests for `getColor`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f71765300832b88a1057e9c967c41